### PR TITLE
Remove dotenv-vault-core. dotenv >16.1.0 has first-class support for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [Unreleased](https://github.com/dotenv-org/dotenv-vault/compare/v1.22.1...master)
+## [Unreleased](https://github.com/dotenv-org/dotenv-vault/compare/v1.22.2...master)
+
+## [1.22.2](https://github.com/dotenv-org/dotenv-vault/compare/v1.22.1...v1.22.2) (2023-05-30)
+
+### Removed
+
+- Removed `dotenv-vault-core`. It is deprecated as `dotenv >= 16.1.0` has added first-class support for `.env.vault` files
 
 ## [1.22.1](https://github.com/dotenv-org/dotenv-vault/compare/v1.22.0...v1.22.1) (2023-05-30)
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "@oclif/plugin-warn-if-update-available": "^2.0.36",
     "axios": "^0.27.2",
     "chalk": "^4.1.2",
-    "dotenv": "16.0.3",
-    "dotenv-vault-core": "0.7.0"
+    "dotenv": "16.1.0"
   },
   "devDependencies": {
     "@oclif/test": "^2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import run from '@oclif/core'
-import {config} from 'dotenv-vault-core'
+import {config} from 'dotenv'
 
 export {
   config,

--- a/src/services/decrypt-service.ts
+++ b/src/services/decrypt-service.ts
@@ -1,7 +1,6 @@
 import {LogService} from '../services/log-service'
 
-import {config, DotenvConfigOutput} from 'dotenv'
-import {decrypt} from 'dotenv-vault-core'
+import {config, DotenvConfigOutput, decrypt} from 'dotenv'
 
 interface DecryptServiceAttrs {
   cmd;

--- a/src/services/local/decrypt-service.ts
+++ b/src/services/local/decrypt-service.ts
@@ -1,7 +1,6 @@
 import {LogService} from '../../services/log-service'
 
-import {config, DotenvConfigOutput} from 'dotenv'
-import {decrypt} from 'dotenv-vault-core'
+import {config, DotenvConfigOutput, decrypt} from 'dotenv'
 
 interface LocalDecryptServiceAttrs {
   cmd;

--- a/test/lib/main.test.ts
+++ b/test/lib/main.test.ts
@@ -3,7 +3,7 @@ import {CliUx} from '@oclif/core'
 import {writeFileSync} from 'node:fs'
 import { fs } from 'memfs';
 
-import {config} from 'dotenv-vault-core'
+import {config} from 'dotenv'
 
 let testPath = 'test/.env'
 const dotenvKey = 'dotenv://:key_1111111111111111111111111111111111111111111111111111111111111111@dotenv.org/vault/.env.vault?environment=production'
@@ -25,7 +25,11 @@ describe('config', () => {
     const result = config({path: testPath})
     const parsed = result.parsed
 
-    expect(parsed.BASIC).to.equal('production')
+    if (parsed) {
+      expect(parsed.BASIC).to.equal('production')
+    } else {
+      throw 'parse is undefined'
+    }
   })
 
   it('parses the .env.vault#DOTENV_KEY staging data', () => {
@@ -34,7 +38,11 @@ describe('config', () => {
     const result = config({path: testPath})
     const parsed = result.parsed
 
-    expect(parsed.BASIC).to.equal('staging')
+    if (parsed) {
+      expect(parsed.BASIC).to.equal('staging')
+    } else {
+      throw 'parse is undefined'
+    }
   })
 
   it('has a short DOTENV_KEY', () => {
@@ -50,8 +58,11 @@ describe('config', () => {
 
     const result = config({path: testPath})
     const parsed = result.parsed
-
-    expect(parsed.BASIC).to.equal('basic')
+    if (parsed) {
+      expect(parsed.BASIC).to.equal('basic')
+    } else {
+      throw 'parse is undefined'
+    }
   })
 
   it('has an incorrect DOTENV_KEY', () => {


### PR DESCRIPTION
….env.vault files