### PR TITLE
Update axios to 1.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@oclif/plugin-not-found": "^2.3.34",
     "@oclif/plugin-update": "^3.1.16",
     "@oclif/plugin-warn-if-update-available": "^2.0.46",
-    "axios": "^0.27.2",
+    "axios": "^1.6.2",
     "chalk": "^4.1.2",
     "dotenv": "^16.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@oclif/plugin-not-found": "^2.3.34",
     "@oclif/plugin-update": "^3.1.16",
     "@oclif/plugin-warn-if-update-available": "^2.0.46",
-    "axios": "^1.6.2",
+    "axios": "^1.6.7",
     "chalk": "^4.1.2",
     "dotenv": "^16.3.1"
   },


### PR DESCRIPTION
This PR updates the `axios` package to 1.6.7, which should resolve the following vulnerability issue: https://github.com/advisories/GHSA-wf5p-g6vw-rhxx

I don't believe the project is affected by this -- I just wanted the warning on my side gone :smile:

One thing: I was following the contribution guidelines but I could not get the tests to run properly, even on master. Am I missing something?