### PR TITLE
Begin deprecating local commands (switch to dotenvx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [Unreleased](https://github.com/dotenv-org/dotenv-vault/compare/v1.24.0...master)
+## [Unreleased](https://github.com/dotenv-org/dotenv-vault/compare/v1.26.0...master)
+
+## [1.26.0](https://github.com/dotenv-org/dotenv-vault/compare/v1.25.0...v1.26.0) (2024-01-23)
+
+### Changed
+
+- Mark `local` commands as deprecated and warn user (to be removed in later release) ([#331](https://github.com/dotenv-org/dotenv-vault/pull/331))
+
+### Added
+
+- Append to vercelignore file if it exists 🔒 ([#297](https://github.com/dotenv-org/dotenv-vault/pull/297))
 
 ## [1.25.0](https://github.com/dotenv-org/dotenv-vault/compare/v1.24.0...v1.25.0) (2023-07-08)
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "topicSeparator": " ",
     "topics": {
       "local": {
-        "description": "Local only commands"
+        "description": "[DEPRECATED][Switch to dotenvx: github.com/dotenvx/dotenvx] Local only commands"
       }
     },
     "update": {

--- a/src/commands/local/build.ts
+++ b/src/commands/local/build.ts
@@ -3,7 +3,7 @@ import {Command} from '@oclif/core'
 import {LocalBuildService} from '../../services/local/build-service'
 
 export default class LocalBuild extends Command {
-  static description = 'Build .env.vault from local only'
+  static description = '[DEPRECATED][Switch to dotenvx: github.com/dotenvx/dotenvx] Build .env.vault from local only'
 
   public async run(): Promise<void> {
     await new LocalBuildService({cmd: this}).run()

--- a/src/commands/local/decrypt.ts
+++ b/src/commands/local/decrypt.ts
@@ -3,7 +3,7 @@ import {Command} from '@oclif/core'
 import {LocalDecryptService} from '../../services/local/decrypt-service'
 
 export default class LocalDecrypt extends Command {
-  static description = 'Decrypt .env.vault from local only'
+  static description = '[DEPRECATED][Switch to dotenvx: github.com/dotenvx/dotenvx] Decrypt .env.vault from local only'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/src/commands/local/keys.ts
+++ b/src/commands/local/keys.ts
@@ -3,7 +3,7 @@ import {Command} from '@oclif/core'
 import {LocalKeysService} from '../../services/local/keys-service'
 
 export default class LocalKeys extends Command {
-  static description = 'List .env.vault local decryption keys from .env.keys file'
+  static description = '[DEPRECATED][Switch to dotenvx: github.com/dotenvx/dotenvx] List .env.vault local decryption keys from .env.keys file'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/src/services/local/build-service.ts
+++ b/src/services/local/build-service.ts
@@ -22,6 +22,8 @@ class LocalBuildService {
   }
 
   async run(): Promise<void> {
+    this.log.deprecated()
+
     new AppendToIgnoreService().run()
 
     const buildMsg = 'Building .env.vault from files on your machine'

--- a/src/services/log-service.ts
+++ b/src/services/log-service.ts
@@ -24,7 +24,7 @@ class LogService {
       msg = ''
     }
 
-    this.cmd.log(`${chalk.red('[DEPRECATED] Please switch to dotenvx – github.com/dotenvx/dotenvx ')}${msg}`)
+    this.cmd.log(`${chalk.red('[DEPRECATED] Please switch to dotenvx (github.com/dotenvx/dotenvx) for all local commands. example: [dotenvx encrypt]')}${msg}`)
   }
 
   plain(msg: string): void {

--- a/src/services/log-service.ts
+++ b/src/services/log-service.ts
@@ -19,6 +19,14 @@ class LogService {
     return 'remote:   '
   }
 
+  deprecated(msg: string): void {
+    if (msg === undefined) {
+      msg = ''
+    }
+
+    this.cmd.log(`${chalk.red('[DEPRECATED] Please switch to dotenvx – github.com/dotenvx/dotenvx ')}${msg}`)
+  }
+
   plain(msg: string): void {
     if (msg === undefined) {
       msg = ''


### PR DESCRIPTION
[dotenvx](https://github.com/dotenvx/dotenvx) has gotten rapidly better. it's commands api is also a little better than using `local` here. `local` will be removed in the next few weeks or so.

please switch to using `dotenvx` which i think you will really like. it is starting to become my tool of choice regarding .env and .env.vault files.