### PR TITLE
feat: add command for generating .env.example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,18 @@ local:    Listing .env.vault decryption keys from .env.keys... done
 dotenv://:key_a682c..@dotenv.local/vault/.env.vault?environment=development
 ```
 
+### `example`
+
+Generate `.env.example` file with keys from a specific environment.
+
+Example:
+
+```bash
+$ npx dotenv-vault@latest example production
+remote:   Securely pulling production... done
+Generated .env.example successfully with keys from production environment.
+```
+
 ## ❓ FAQ
 
 ### Why is the `.env.vault` file not decrypting my environment variables successfully?

--- a/src/commands/example.ts
+++ b/src/commands/example.ts
@@ -1,9 +1,8 @@
 import {Command, Flags} from '@oclif/core'
+import {ExampleService} from '../services/example-service'
 
-import {PullService} from '../services/pull-service'
-
-export default class Pull extends Command {
-  static description = 'Pull .env securely'
+export default class Example extends Command {
+  static description = 'Generate .env.example file from .env'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
@@ -13,15 +12,15 @@ export default class Pull extends Command {
     {
       name: 'environment',
       required: false,
-      description: 'Set environment to pull from. Defaults to development (writing to .env)',
+      description: 'Set environment to create .env.example from. Defaults to production',
       hidden: false,
     },
     {
       name: 'filename',
       required: false,
-      description: 'Set output filename. Defaults to .env for development and .env.{environment} for other environments',
+      description: 'Set output filename. Defaults to .env.example',
       hidden: false,
-    },
+    }
   ]
 
   static flags = {
@@ -36,19 +35,18 @@ export default class Pull extends Command {
     yes: Flags.boolean({
       char: 'y',
       description: 'Automatic yes to prompts. Assume yes to all prompts and run non-interactively.',
-      hidden: false,
       required: false,
       default: false,
     }),
   }
 
   public async run(): Promise<void> {
-    const {args, flags} = await this.parse(Pull)
-    const environment = args.environment
-    const filename = args.filename
-    const dotenvMe = flags.dotenvMe
+    const {flags} = await this.parse(Example)
     const yes = flags.yes
+    const environment = flags.environment
+    const filename = flags.filename
+    const dotenvMe = flags.dotenvMe
 
-    await new PullService({cmd: this, environment: environment, filename: filename, dotenvMe: dotenvMe, yes: yes}).run(true)
+    await new ExampleService({cmd: this, yes: yes, environment: environment, filename: filename, dotenvMe: dotenvMe}).run()
   }
 }

--- a/src/services/example-service.ts
+++ b/src/services/example-service.ts
@@ -1,0 +1,93 @@
+import { existsSync, writeFileSync } from 'fs'
+import { CliUx } from '@oclif/core'
+import { LogService } from './log-service'
+import { AbortService } from './abort-service'
+import { PullService } from './pull-service'
+import chalk from 'chalk'
+import * as dotenv from 'dotenv'
+
+interface ExampleServiceAttrs {
+  cmd: any;
+  yes: boolean;
+  environment?: string;
+  filename: string;
+  dotenvMe?: string;
+}
+
+class ExampleService {
+  public cmd: any;
+  public fileName?: string;
+  public yes: boolean;
+  public log: LogService;
+  public abort: AbortService;
+  public pull: PullService;
+  public environment: string;
+
+  constructor(attrs: ExampleServiceAttrs = {} as ExampleServiceAttrs) {
+    this.cmd = attrs.cmd
+    this.yes = attrs.yes
+    this.environment = attrs.environment ?? 'production'
+    this.fileName = attrs.filename
+
+    this.log = new LogService({ cmd: attrs.cmd })
+    this.abort = new AbortService({ cmd: attrs.cmd })
+    this.pull = new PullService({
+      cmd: attrs.cmd,
+      yes: this.yes,
+      environment: this.environment,
+      filename: undefined,
+      dotenvMe: attrs.dotenvMe
+    })
+  }
+
+  async run(): Promise<void> {
+    CliUx.ux.action.start(`${chalk.dim(this.log.pretextRemote)}Pulling ${this.environment} environment`)
+
+    const outputFile = this.fileName ?? '.env.example'
+
+    // Check if output file exists
+    if (existsSync(outputFile) && !this.yes) {
+      const overwrite = await CliUx.ux.confirm(`${outputFile} already exists. Overwrite?`)
+
+      if (!overwrite) {
+        this.log.plain('Operation cancelled.')
+        return
+      }
+    }
+
+    // Pull environment data
+    let envData: string | undefined
+    try {
+      // Get environment data without writing to file
+      envData = await this.pull.run(false)
+    } catch (error) {
+      CliUx.ux.action.stop('failed')
+      this.log.remote(`Failed to pull ${this.environment} environment: ${error.message}`)
+      return
+    }
+    if (!envData) {
+      CliUx.ux.action.stop('failed')
+      this.log.remote('No data received from pull service')
+      return
+    }
+
+    // Get keys from the environment data
+    const parsed = dotenv.parse(envData)
+    const keys = Object.keys(parsed)
+
+    // Generate the example content
+    const exampleLines = [`# Example .env file generated from the '${this.environment}' environment`]
+    for (const key of keys) {
+      exampleLines.push(`${key}=${key.toLowerCase()}`)
+    }
+    const exampleContent = exampleLines.join('\n')
+
+    // Write example file
+    writeFileSync(outputFile, exampleContent)
+    this.log.plain(`Generated ${outputFile} successfully with keys from ${this.environment} environment.`)
+
+    CliUx.ux.action.stop()
+  }
+}
+
+export { ExampleService }


### PR DESCRIPTION
This adds an `example` command that generates a `.env.example` file for a given environment.

```bash
$ npx dotenv-vault@latest example production
remote:   Securely pulling production... done
Generated .env.example successfully with keys from production environment.
```

```
# Example .env file generated from the 'production' environment
HELLO=hello
```